### PR TITLE
[feature] 카테고리 별 페이지 생성

### DIFF
--- a/public/posts/[LOG]2024-11-18.md
+++ b/public/posts/[LOG]2024-11-18.md
@@ -3,7 +3,7 @@ title: "[LOG] 2024-11-18 TIL"
 date: "2024-11-18"
 tags: ["React", "JavaScript", "CORS"]
 category:
-  main: "Log"
+  main: "dev"
   sub: "TIL"
 thumbnail: "/images/[LOG]2024-11-18/1.png"
 ---

--- a/public/posts/[LOG]2024-11-19.md
+++ b/public/posts/[LOG]2024-11-19.md
@@ -3,7 +3,7 @@ title: "[LOG] 2024-11-19 TIL"
 date: "2024-11-19"
 tags: ["React", "JavaScript", "Backend", "Google Cloud", "CORS"]
 category:
-  main: "Log"
+  main: "dev"
   sub: "TIL"
 ---
 

--- a/public/posts/[LOG]2024-11-20.md
+++ b/public/posts/[LOG]2024-11-20.md
@@ -1,9 +1,9 @@
 ---
 title: "[LOG]2024-11-20 TIL"
 date: "2024-11-20"
-tags: ["example",""]
+tags: ["example", ""]
 category:
-  main: ""
+  main: "dev"
   sub: ""
 ---
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,30 +3,37 @@
   
   <url>
     <loc>https://blog.howu.run</loc>
-    <lastmod>2024-12-18T02:43:22.649Z</lastmod>
+    <lastmod>2024-12-27T19:32:46.429Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>1</priority>
   </url>
   
   <url>
     <loc>https://blog.howu.run/post/[LOG]2024-11-18</loc>
-    <lastmod>2024-12-18T02:43:22.649Z</lastmod>
+    <lastmod>2024-12-27T19:32:46.432Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   
   <url>
     <loc>https://blog.howu.run/post/[LOG]2024-11-19</loc>
-    <lastmod>2024-12-18T02:43:22.649Z</lastmod>
+    <lastmod>2024-12-27T19:32:46.433Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   
   <url>
     <loc>https://blog.howu.run/post/[LOG]2024-11-20</loc>
-    <lastmod>2024-12-18T02:43:22.649Z</lastmod>
+    <lastmod>2024-12-27T19:32:46.433Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  
+  <url>
+    <loc>https://blog.howu.run/category/dev</loc>
+    <lastmod>2024-12-27T19:32:46.433Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
   
 </urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import fm from "front-matter"; // front-matter 사용하여 md 파일에서 데이터 추출
 
 // 프로젝트 루트와 경로 설정
 const PUBLIC_DIR = path.resolve("./public");
@@ -20,17 +21,41 @@ const generateSitemap = () => {
     },
   ];
 
+  const categories = new Set(); // 카테고리 중복 방지용 Set
+
   // 게시물 데이터 읽기
   const posts = fs
     .readdirSync(POSTS_DIR)
     .filter((file) => file.endsWith(".md"));
+
   posts.forEach((post) => {
+    const postPath = path.join(POSTS_DIR, post);
+    const markdown = fs.readFileSync(postPath, "utf-8");
+    const { attributes } = fm(markdown); // front-matter에서 데이터 추출
+
     const postSlug = post.replace(".md", "");
+
+    // 게시글 URL 추가
     urls.push({
       loc: `${BASE_URL}/post/${postSlug}`,
       lastmod: new Date().toISOString(),
       changefreq: "weekly",
       priority: 0.8,
+    });
+
+    // 카테고리 URL 추가
+    if (attributes.category && attributes.category.main) {
+      categories.add(attributes.category.main);
+    }
+  });
+
+  // 카테고리별 URL 생성
+  categories.forEach((category) => {
+    urls.push({
+      loc: `${BASE_URL}/category/${category}`,
+      lastmod: new Date().toISOString(),
+      changefreq: "weekly",
+      priority: 0.7,
     });
   });
 

--- a/src/pages/CategoryPage/CategoryPage.jsx
+++ b/src/pages/CategoryPage/CategoryPage.jsx
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import PostList from "../../shared/ui/PostList/PostList";
+import { getPosts } from "../../utils/postService";
+
+function CategoryPage() {
+  const { main } = useParams();
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      const data = await getPosts(main);
+      setPosts(data);
+      console.log(main);
+    };
+    fetchPosts();
+  }, [main]);
+
+  return (
+    <div>
+      <h2>{main.toUpperCase()} 게시판</h2>
+      <PostList posts={posts} />
+    </div>
+  );
+}
+
+export default CategoryPage;

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -108,11 +108,6 @@ function PostDetail() {
       <header className="post-detail__header">
         <h1 className="post-detail__header-title">{postTitle}</h1>
         <p className="post-detail__header-date">{postDate}</p>
-        <div className="post-detail__header-category">
-          <span className="post-detail__header-category-main">
-            {postCategory.main + "/" + postCategory.sub}
-          </span>
-        </div>
         <div className="post-detail__header-tags">
           {postTags.map((tag, index) => (
             <Tag key={index} label={tag} />

--- a/src/shared/ui/PostList/PostList.scss
+++ b/src/shared/ui/PostList/PostList.scss
@@ -3,7 +3,7 @@
 .post-list {
   display: grid;
   grid-template-columns: repeat(
-    auto-fit,
+    auto-fill,
     minmax(280px, 1fr)
   ); // 바둑판 레이아웃
   gap: 20px;

--- a/src/utils/postService.js
+++ b/src/utils/postService.js
@@ -1,41 +1,65 @@
 import fm from "front-matter";
 
-export async function getPosts() {
-  // posts.json 파일에서 파일 목록 가져오기
-  const fileNames = await fetch("/posts.json").then((res) => res.json());
+// 전체 포스트 목록 또는 카테고리별 포스트 목록 불러오기
+export async function getPosts(category = null) {
+  try {
+    const fileNames = await fetch("/posts.json").then((res) => res.json());
 
-  const postData = await Promise.all(
-    fileNames.map(async (postId) => {
-      const markdown = await fetch(`/posts/${postId}.md`).then((res) =>
-        res.text()
-      );
-      const { attributes, body } = fm(markdown);
-      return {
-        id: postId,
-        title: attributes.title,
-        date: attributes.date,
-        excerpt: body.slice(0, 100) + "...",
-        category: attributes.category,
-        tags: attributes.tags || [],
-        thumbnail: attributes.thumbnail || "/images/default.png",
-      };
-    })
-  );
+    const postData = await Promise.all(
+      fileNames.map(async (postId) => {
+        const markdown = await fetch(`/posts/${postId}.md`).then((res) =>
+          res.text()
+        );
+        const { attributes, body } = fm(markdown);
 
-  // 날짜 기준 내림차순 정렬
-  return postData.sort((a, b) => new Date(b.date) - new Date(a.date));
+        return {
+          id: postId,
+          title: attributes.title,
+          date: attributes.date,
+          excerpt: body.slice(0, 100) + "...",
+          category: attributes.category.main,
+          subCategory: attributes.category.sub,
+          tags: attributes.tags || [],
+          thumbnail: attributes.thumbnail || "/images/default.png",
+          content: body,
+        };
+      })
+    );
+
+    // 카테고리 필터링
+    const filteredPosts = category
+      ? postData.filter((post) => post.category === category)
+      : postData;
+
+    return filteredPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
+  } catch (error) {
+    console.error("Failed to fetch posts:", error);
+    return [];
+  }
 }
 
+// 특정 게시글 불러오기
 export async function getPost(id) {
-  const response = await fetch(`/posts/${id}.md`);
-  const markdown = await response.text();
-  const { attributes, body } = fm(markdown);
-  return {
-    title: attributes.title,
-    date: attributes.date,
-    category: attributes.category,
-    tags: attributes.tags || [],
-    content: body,
-    thumbnail: attributes.thumbnail || "/images/default.png",
-  };
+  try {
+    const response = await fetch(`/posts/${id}.md`);
+    const markdown = await response.text();
+    const { attributes, body } = fm(markdown);
+
+    return {
+      title: attributes.title,
+      date: attributes.date,
+      category: attributes.category.main,
+      subCategory: attributes.category.sub,
+      tags: attributes.tags || [],
+      content: body,
+      thumbnail: attributes.thumbnail || "/images/default.png",
+    };
+  } catch (error) {
+    console.error(`Failed to fetch post: ${id}`, error);
+    return null;
+  }
+}
+
+export async function getPostsByCategory(category) {
+  return await getPosts(category);
 }

--- a/src/widgets/Footer/Footer.jsx
+++ b/src/widgets/Footer/Footer.jsx
@@ -28,7 +28,7 @@ function Footer() {
           />
         </a>
       </div>
-      <p className="footer__text">&copy; 2024 My Markdown Blog</p>
+      <p className="footer__text">&copy; 2024 Howu Blog</p>
     </footer>
   );
 }

--- a/src/widgets/Header/Header.jsx
+++ b/src/widgets/Header/Header.jsx
@@ -3,11 +3,11 @@ import { Link } from "react-router-dom";
 import styles from "./Header.module.scss";
 
 const NAV_ITEMS = [
-  { path: "/", label: "All" },
-  { path: "/", label: "Dev" },
-  { path: "/", label: "Plan" },
-  { path: "/", label: "UI/UX" },
-  { path: "/", label: "Story" },
+  { path: "/", label: "ALL" },
+  { path: "/category/dev", label: "Dev" },
+  { path: "/category/plan", label: "Plan" },
+  { path: "/category/uiux", label: "UI/UX" },
+  { path: "/category/story", label: "Story" },
 ];
 
 function Header() {

--- a/src/widgets/Layout/Layout.jsx
+++ b/src/widgets/Layout/Layout.jsx
@@ -5,6 +5,7 @@ import Footer from "../Footer/Footer";
 import RightSidebar from "../../shared/ui/RightSidebar/RightSidebar";
 import Home from "../../pages/Home/Home";
 import PostDetail from "../../pages/PostDetail/PostDetail";
+import CategoryPage from "../../pages/CategoryPage/CategoryPage";
 import Carousel from "../../shared/ui/Carousel/Carousel";
 import styles from "./Layout.module.scss";
 
@@ -20,6 +21,7 @@ function Layout() {
     >
       <Header className={styles.app__header} />
 
+      {/* 캐러셀은 홈, 카테고리 페이지에서만 보이게 설정 */}
       {!isPostDetailPage && (
         <div className={styles.app__carousel}>
           <Carousel />
@@ -29,11 +31,18 @@ function Layout() {
       <div className={styles.app__main}>
         <main className={styles["app__main-content"]}>
           <Routes>
+            {/* 홈 페이지 */}
             <Route path="/" element={<Home />} />
+
+            {/* 게시글 상세 */}
             <Route path="/post/:id" element={<PostDetail />} />
+
+            {/* 카테고리 페이지 (동적 라우팅) */}
+            <Route path="/category/:main" element={<CategoryPage />} />
           </Routes>
         </main>
 
+        {/* 우측 사이드바는 상세 페이지에서 숨김 */}
         {!isPostDetailPage && (
           <RightSidebar className={styles["app__sidebar"]} />
         )}


### PR DESCRIPTION
### 변경 사항 설명
카테고리별 페이지(`/category/:main`)를 구현하고, 사이트맵에 카테고리 URL을 포함하도록 수정했습니다.  
게시글 필터링 기능을 추가해 특정 카테고리의 게시글만 표시되도록 했습니다.

### 관련 이슈
- 이슈 번호: #17

### 변경 사항 상세 설명
1. **카테고리 페이지 구현**  
   - `/category/:main` 경로에서 카테고리별 게시글을 렌더링하는 `CategoryPage` 생성  
   - `useParams`를 통해 URL에서 카테고리를 추출하고, 해당하는 게시글만 필터링  
2. **라우팅 설정**
   - Layout.js에서 /category/:main 라우트 추가
3. **사이트맵 수정**
   - 게시글 마크다운에서 category.main을 추출해 중복 없이 사이트맵에 추가

### 테스트 방법
- /category/Dev, /category/Plan 페이지에서 카테고리별 게시글이 렌더링되는지 확인
- node generateSitemap.js 실행 후 sitemap.xml에서 카테고리 URL 포함 여부 확인
- 게시글이 1개일 때 레이아웃이 깨지지 않는지 반응형 테스트