### PR TITLE
[hotfix] PostList 전체 글 노출 문제 수정

### DIFF
--- a/src/shared/ui/PostList/PostList.jsx
+++ b/src/shared/ui/PostList/PostList.jsx
@@ -5,8 +5,7 @@ import "./PostList.scss";
 function PostList({ posts }) {
   const sortedPosts = posts
     .slice()
-    .sort((a, b) => new Date(b.date) - new Date(a.date)) // 최신 날짜 기준 정렬
-    .slice(0, 3);
+    .sort((a, b) => new Date(b.date) - new Date(a.date)); // 최신 날짜 기준 정렬
 
   return (
     <div className="post-list">


### PR DESCRIPTION
### 변경 사항 설명
`PostList` 컴포넌트에서 `slice(0, 3)`가 있어 모든 글이 노출되지 않는 문제를 수정했습니다.  

### 변경 사항 상세 설명
- `PostList`에서 `slice(0, 3)`를 삭제해 전체 포스트가 보이게 수정
- 변경된 파일: `PostList.js`  
- 영향 범위: 블로그 메인 페이지 및 포스트 목록 페이지  

### 추가 정보
긴급 수정 사항으로 별도의 기능 추가 없이 버그만 수정되었습니다.  
배포 후 바로 테스트 진행 부탁드립니다.
