### PR TITLE
[style] 네브바 제외 폰트 수정 및 포스트 아이템 마진 수정

### DIFF
--- a/src/core/index.scss
+++ b/src/core/index.scss
@@ -1,3 +1,5 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
+
 @font-face {
   font-family: "D2Coding";
   src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_three@1.0/D2Coding.woff")
@@ -5,10 +7,11 @@
   font-weight: normal;
   font-style: normal;
 }
+
 :root {
   font-size: 100%;
   line-height: 1.5;
-  font-family: system-ui, sans-serif;
+  font-family: "Pretendard", sans-serif;
 }
 
 *,
@@ -33,7 +36,6 @@ body {
   text-size-adjust: 100%;
   color: inherit;
   background-color: #fff;
-  font-family: "D2Coding", monospace;
 }
 
 a {

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -8,6 +8,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import remarkGfm from "remark-gfm";
 import { Helmet } from "react-helmet-async";
 import Tag from "../../shared/ui/Tag/Tag";
+import Toc from "../../shared/ui/Toc/Toc";
 import "highlight.js/styles/github.css";
 import "./PostDetail.scss";
 
@@ -56,50 +57,6 @@ function PostDetail() {
     <div className="post-detail">
       <Helmet>
         <title>{postTitle ? `${postTitle} - Howu` : "Howu 블로그"}</title>
-        <meta
-          name="description"
-          content={
-            postContent
-              ? postContent.substring(0, 150)
-              : "Howu 블로그 글입니다."
-          }
-        />
-        <meta property="og:title" content={postTitle || "Howu 블로그"} />
-        <meta
-          property="og:description"
-          content={
-            postContent
-              ? postContent.substring(0, 150)
-              : "Howu 블로그 글입니다."
-          }
-        />
-        <meta property="og:type" content="article" />
-        <meta property="og:url" content={`https://blog.howu.run/post/${id}`} />
-        <meta
-          property="og:image"
-          content={
-            postCategory.thumbnailUrl ||
-            "https://blog.howu.run/images/default-thumbnail.jpg"
-          }
-        />
-
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={postTitle || "Howu 블로그"} />
-        <meta
-          name="twitter:description"
-          content={
-            postContent
-              ? postContent.substring(0, 150)
-              : "Howu 블로그 글입니다."
-          }
-        />
-        <meta
-          name="twitter:image"
-          content={
-            postCategory.thumbnailUrl ||
-            "https://blog.howu.run/images/default-thumbnail.jpg"
-          }
-        />
       </Helmet>
 
       <header className="post-detail__header">
@@ -133,57 +90,14 @@ function PostDetail() {
               rehypeSlug,
               [rehypeAutolinkHeadings, { behavior: "wrap" }],
             ]}
-            components={{
-              p({ children, ...props }) {
-                const highlightRegex = /==\((파랑|노랑|빨강)\)(.+?)==/g;
-                const parts = children.toString().split(highlightRegex);
-
-                return (
-                  <p {...props}>
-                    {parts.map((part, index) => {
-                      if (index % 3 === 1) {
-                        const colorClass =
-                          {
-                            파랑: "highlight--blue",
-                            노랑: "highlight--yellow",
-                            빨강: "highlight--red",
-                          }[part] || "highlight";
-
-                        return (
-                          <mark
-                            key={index}
-                            className={`highlight ${colorClass}`}
-                          >
-                            {parts[index + 1]}
-                          </mark>
-                        );
-                      }
-                      return part;
-                    })}
-                  </p>
-                );
-              },
-            }}
           >
             {postContent}
           </ReactMarkdown>
         </div>
       </main>
 
-      <aside className="post-detail__toc">
-        <h2 className="post-detail__toc-title">{postTitle}</h2>
-        <ul className="post-detail__toc-list">
-          {headings.map((heading) => (
-            <li
-              key={heading.id}
-              className="post-detail__toc-list-item"
-              style={{ marginLeft: (heading.level - 1) * 10 }}
-            >
-              <a href={`#${heading.id}`}>{heading.text}</a>
-            </li>
-          ))}
-        </ul>
-      </aside>
+      {/* TOC 컴포넌트 사용 */}
+      <Toc headings={headings} postTitle={postTitle} />
     </div>
   );
 }

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -53,6 +53,29 @@ function PostDetail() {
     }
   }, [postContent]);
 
+  const renderCustomText = (text) => {
+    const highlightRegex = /==\((파랑|노랑|빨강)\)(.+?)==/g;
+    const parts = text.split(highlightRegex);
+
+    return parts.map((part, index) => {
+      if (index % 3 === 1) {
+        const colorClass =
+          {
+            파랑: "highlight--blue",
+            노랑: "highlight--yellow",
+            빨강: "highlight--red",
+          }[part] || "highlight";
+
+        return (
+          <mark key={index} className={`highlight ${colorClass}`}>
+            {parts[index + 1]}
+          </mark>
+        );
+      }
+      return part;
+    });
+  };
+
   return (
     <div className="post-detail">
       <Helmet>
@@ -90,13 +113,19 @@ function PostDetail() {
               rehypeSlug,
               [rehypeAutolinkHeadings, { behavior: "wrap" }],
             ]}
+            components={{
+              p({ children, ...props }) {
+                return (
+                  <p {...props}>{renderCustomText(children.toString())}</p>
+                );
+              },
+            }}
           >
             {postContent}
           </ReactMarkdown>
         </div>
       </main>
 
-      {/* TOC 컴포넌트 사용 */}
       <Toc headings={headings} postTitle={postTitle} />
     </div>
   );

--- a/src/pages/PostDetail/PostDetail.scss
+++ b/src/pages/PostDetail/PostDetail.scss
@@ -149,46 +149,6 @@
       }
     }
   }
-
-  &__toc {
-    position: fixed;
-    top: 0;
-    right: 0;
-    width: 200px;
-    margin-top: 100px;
-    margin-right: 50px;
-    padding: 15px;
-    border: 0.5px dotted $primary-40;
-    border-radius: 8px;
-
-    &-title {
-      font-size: 1.2rem;
-      font-weight: bold;
-    }
-
-    &-list-item {
-      margin-bottom: 5px;
-      white-space: normal;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      line-height: 1.4;
-      max-height: 2.8em;
-
-      a {
-        color: $b-700;
-        text-decoration: none;
-        display: block;
-        max-width: 100%;
-
-        &:hover {
-          color: $primary-100;
-        }
-      }
-    }
-  }
 }
 
 .post-detail__content-markdown {
@@ -257,10 +217,6 @@
 
     &__content {
       font-size: 0.95rem;
-    }
-
-    &__toc {
-      display: none;
     }
   }
 }

--- a/src/shared/ui/PostItem/PostItem.scss
+++ b/src/shared/ui/PostItem/PostItem.scss
@@ -30,7 +30,6 @@
 
   &__thumbnail {
     width: 100%;
-    max-width: 250px; // 최대 너비 300px
     height: 140px; // 높이 140px 고정
     border-radius: 8px;
     object-fit: cover;
@@ -42,7 +41,6 @@
     font-size: 1.5rem;
     font-weight: bold;
     width: 100%; // 전체 너비 설정
-    max-width: 250px; // 최대 너비 설정
     white-space: nowrap; // 줄 바꿈 방지
     overflow: hidden; // 넘치는 텍스트 숨김
     text-overflow: ellipsis; // 말줄임표로 처리

--- a/src/shared/ui/Toc/Toc.jsx
+++ b/src/shared/ui/Toc/Toc.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import styles from "./Toc.module.scss";
+
+function Toc({ headings, postTitle }) {
+  return (
+    <aside className={styles.toc}>
+      <h2 className={styles.toc__title}>{postTitle}</h2>
+      <ul className={styles.toc__list}>
+        {headings.map((heading) => (
+          <li
+            key={heading.id}
+            className={styles.toc__listItem}
+            style={{ marginLeft: (heading.level - 1) * 10 }}
+          >
+            <a href={`#${heading.id}`}>{heading.text}</a>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+export default Toc;

--- a/src/shared/ui/Toc/Toc.jsx
+++ b/src/shared/ui/Toc/Toc.jsx
@@ -6,15 +6,18 @@ function Toc({ headings, postTitle }) {
     <aside className={styles.toc}>
       <h2 className={styles.toc__title}>{postTitle}</h2>
       <ul className={styles.toc__list}>
-        {headings.map((heading) => (
-          <li
-            key={heading.id}
-            className={styles.toc__listItem}
-            style={{ marginLeft: (heading.level - 1) * 10 }}
-          >
-            <a href={`#${heading.id}`}>{heading.text}</a>
-          </li>
-        ))}
+        {headings.map((heading) => {
+          const levelClass = styles[`toc__list-item--level-${heading.level}`];
+          return (
+            <li
+              key={heading.id}
+              className={`${styles.toc__listItem} ${levelClass}`}
+              style={{ marginLeft: (heading.level - 1) * 10 }}
+            >
+              <a href={`#${heading.id}`}>{heading.text}</a>
+            </li>
+          );
+        })}
       </ul>
     </aside>
   );

--- a/src/shared/ui/Toc/Toc.module.scss
+++ b/src/shared/ui/Toc/Toc.module.scss
@@ -20,25 +20,54 @@
   &__list {
     list-style: none;
     padding-left: 0;
+  }
 
-    &-item {
-      margin-bottom: 5px;
-      white-space: normal;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      line-height: 1.4;
+  &__listItem {
+    margin-bottom: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+    display: block;
 
-      a {
-        color: #333;
-        text-decoration: none;
-
-        &:hover {
-          color: #0070c0;
-        }
-      }
+    a {
+      text-decoration: none;
+      display: block;
+      max-width: 100%;
     }
+
+    &--level-1 {
+      font-size: 1.2rem;
+      color: var(--b-900);
+    }
+
+    &--level-2 {
+      font-size: 1.1rem;
+      color: var(--b-700);
+    }
+
+    &--level-3 {
+      font-size: 1rem;
+      color: var(--b-500);
+    }
+
+    &--level-4 {
+      font-size: 0.95rem;
+      color: var(--b-400);
+    }
+
+    &--level-5,
+    &--level-6 {
+      font-size: 0.9rem;
+      color: var(--b-300);
+    }
+
+    a:hover {
+      color: var(--primary-100);
+    }
+  }
+
+  @media (max-width: 768px) {
+    display: none;
   }
 }

--- a/src/shared/ui/Toc/Toc.module.scss
+++ b/src/shared/ui/Toc/Toc.module.scss
@@ -1,0 +1,44 @@
+@use "@styles/_variables.scss" as *;
+
+.toc {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 200px;
+  margin-top: 100px;
+  margin-right: 50px;
+  padding: 15px;
+  border: 0.5px dotted $primary-100;
+  border-radius: 8px;
+
+  &__title {
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
+
+  &__list {
+    list-style: none;
+    padding-left: 0;
+
+    &-item {
+      margin-bottom: 5px;
+      white-space: normal;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      line-height: 1.4;
+
+      a {
+        color: #333;
+        text-decoration: none;
+
+        &:hover {
+          color: #0070c0;
+        }
+      }
+    }
+  }
+}

--- a/src/widgets/Header/Header.module.scss
+++ b/src/widgets/Header/Header.module.scss
@@ -7,6 +7,7 @@
   justify-content: center;
   align-items: center;
   border-bottom: 0.5px solid $primary-40;
+  font-family: "D2Coding", monospace;
 
   &__wrapper {
     max-width: 1100px;


### PR DESCRIPTION
## 변경 사항 설명
- **네비게이션 바를 제외한 모든 페이지의 폰트를 Pretendard로 수정**하였습니다.  
- **포스트 리스트 아이템의 마진을 조정하여 사용자 경험을 개선했습니다.  

## 관련 이슈
- 이슈 번호: #28 

## 변경 사항 상세 설명
- **글로벌 폰트 변경**  
  - `@font-face` 및 `body` 스타일에 `Pretendard` 폰트를 적용했습니다.  
  - 네비게이션 바(`.header` 및 `.nav`)는 기존 폰트를 유지하고, 다른 모든 페이지 요소에 `Pretendard`가 적용됩니다.  
  - SCSS에서 `:root`와 `body`를 수정하여 폰트 상속이 전체 페이지에 일괄 적용됩니다.  

- **포스트 리스트 아이템 너비 수정**  
  - `.post-list__item`의 너비를 조정하여 포스트 아이템들의 내용이 한 눈에 파악하기 쉽게 개선했습니다.  
