### PR TITLE
[hotfix]포스트 내용에서 이미지가 [object Object]로 나오는 오류 수정

### DIFF
--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -111,9 +111,32 @@ function PostDetail() {
               [rehypeAutolinkHeadings, { behavior: "wrap" }],
             ]}
             components={{
-              p({ children }) {
-                return <p dangerouslySetInnerHTML={{ __html: children }} />;
+              img: ({ node, ...props }) => {
+                const src = props.src.startsWith("http")
+                  ? props.src
+                  : `${window.location.origin}${props.src}`;
+
+                return (
+                  <img
+                    {...props}
+                    src={src}
+                    alt={props.alt || "이미지"}
+                    loading="lazy"
+                    className="post-detail__image"
+                  />
+                );
               },
+              p({ node, children }) {
+                // children이 배열인지 확인하고 이미지가 포함된 경우 처리
+                if (
+                  Array.isArray(children) &&
+                  children.some((child) => child?.type === "img")
+                ) {
+                  return <>{children}</>;
+                }
+                return <p>{children}</p>;
+              },
+
               input({ node, ...props }) {
                 if (props.type === "checkbox") {
                   return (


### PR DESCRIPTION
### 변경 사항 설명

포스트의 마크다운 내용을 렌더링하는 ReactMarkdown 컴포넌트에서 이미지가 `[object Object]`로 출력되는 문제를 수정했습니다.

`img` 태그가 `p` 태그로 감싸질 때, 불필요한 dangerouslySetInnerHTML로 인해 발생하는 렌더링 오류를 해결했습니다.

- 이미지 렌더링을 위한 img 컴포넌트 수정
- p 태그 내에서 img가 감싸지지 않도록 조건 추가

---

### 변경 사항 상세 설명

1. **img 컴포넌트 수정**
    - 이미지 URL 인코딩을 제거하고, 원본 경로를 직접 사용하도록 수정했습니다.
    - 경로가 `http`로 시작하지 않는 경우 `window.location.origin`을 통해 절대 경로로 변환합니다.
2. **p 태그 내 이미지 렌더링 수정**
    - p 태그 안에 img가 포함된 경우, p 태그로 감싸지 않도록 조건을 추가했습니다.
    - 이를 통해 이미지가 `[object Object]`로 출력되지 않고 정상적으로 렌더링됩니다.

수정된 코드 예시:

```jsx
p({ node, children }) {
  if (Array.isArray(children) && children.some((child) => child?.type === "img")) {
    return <>{children}</>;
  }
  return <p>{children}</p>;
},
```

---

### 테스트 방법

변경 사항이 테스트된 방법을 설명해 주세요.

1. **테스트 환경**: 로컬에서 `localhost:3000`으로 실행
2. **테스트 시나리오**:
    - 포스트 내용에 마크다운으로 이미지 추가
    - 마크다운 이미지 경로 예시:![테스트 이미지](/images/SCSS 기본/1.png)
    - 렌더링 결과: 이미지가 정상적으로 표시됨
3. **테스트 결과**:
    - 이미지가 `[object Object]`로 나오던 문제가 해결됨
    - 이미지가 DOM에 올바르게 삽입됨

---

### 추가 정보

- 마크다운에서 한글 및 공백이 포함된 이미지 경로는 URL 인코딩(`%20`)을 직접 적용해 작성해야 합니다.
- 이미지가 렌더링되지 않으면, 브라우저의 네트워크 탭에서 이미지 요청이 발생하는지 확인해 주세요.

예시:

```jsx
![테스트 이미지](/images/SCSS%20기본/1.png)
```