### PR TITLE
[hotfix] 포스트에서 하이라이트랑 강조가 제대로 나오지 않는 오류 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vercel/analytics": "^1.4.1",
         "@vercel/speed-insights": "^1.1.0",
+        "dompurify": "^3.2.3",
         "front-matter": "^4.0.2",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.10.0",
@@ -1707,6 +1708,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2591,6 +2599,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-syntax-highlighter": "^15.6.1",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-highlight": "^7.0.1",
+        "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.0",
@@ -3544,6 +3545,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.2.tgz",
+      "integrity": "sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/hastscript": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
+      "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
@@ -3578,6 +3629,55 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/hast-util-sanitize": {
@@ -3639,6 +3739,25 @@
         "style-to-object": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6307,6 +6426,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
@@ -7292,6 +7426,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
@@ -7364,6 +7512,16 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-syntax-highlighter": "^15.6.1",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-highlight": "^7.0.1",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@vercel/analytics": "^1.4.1",
     "@vercel/speed-insights": "^1.1.0",
+    "dompurify": "^3.2.3",
     "front-matter": "^4.0.2",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.10.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,8 +19,5 @@ export default defineConfig({
   },
   build: {
     outDir: "dist", // 빌드 결과 디렉토리
-    rollupOptions: {
-      external: ["rehype-raw", "dompurify"],
-    },
   },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,5 +19,8 @@ export default defineConfig({
   },
   build: {
     outDir: "dist", // 빌드 결과 디렉토리
+    rollupOptions: {
+      external: ["rehype-raw"],
+    },
   },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
   build: {
     outDir: "dist", // 빌드 결과 디렉토리
     rollupOptions: {
-      external: ["rehype-raw"],
+      external: ["rehype-raw", "dompurify"],
     },
   },
 });


### PR DESCRIPTION
### 변경 사항 설명

포스트에서 `==(파랑)강조 텍스트==` 형식의 하이라이트가 제대로 렌더링되지 않는 문제를 수정했습니다.

리스트 항목(`<li>`) 및 문단(`<p>`) 내에서 형광펜이나 HTML 마크업이 포함될 경우 `dangerouslySetInnerHTML`을 사용하도록 수정했습니다.

HTML 마크업이 없는 경우 기존 방식으로 렌더링됩니다.

---

### 변경 사항 상세 설명

1. **rehype 플러그인 추가:**`rehypeHighlightText` 플러그인을 만들어 `==(파랑)강조 텍스트==`와 같은 형식을 감지하고, `<mark>` 태그로 변환합니다.
2. **HTML 감지 로직:**`p` 및 `li` 태그에서 HTML 마크업이 감지되면 `dangerouslySetInnerHTML`을 사용하고, 그렇지 않은 경우에는 일반적으로 React 요소로 렌더링합니다.
3. **DOMPurify를 사용해 보안 강화:**`postContent`는 DOMPurify로 필터링한 후 렌더링됩니다.

---

### 코드 변경

```jsx
<ReactMarkdown
  remarkPlugins={[remarkGfm]}
  rehypePlugins={[
    rehypeHighlight,
    rehypeSlug,
    rehypeHighlightText,
    rehypeRaw,
    [rehypeAutolinkHeadings, { behavior: "wrap" }],
  ]}
  components={{
    li({ children }) {
      const content = Array.isArray(children)
        ? children.join("")
        : children;

      const hasHtml = /<[^>]+>/.test(content);

      return hasHtml ? (
        <li dangerouslySetInnerHTML={{ __html: content }} />
      ) : (
        <li>{children}</li>
      );
    },
    p({ children }) {
      const content = Array.isArray(children)
        ? children.join("")
        : children;

      const hasHtml = /<[^>]+>/.test(content);

      return hasHtml ? (
        <p dangerouslySetInnerHTML={{ __html: content }} />
      ) : (
        <p>{children}</p>
      );
    },
    img: ({ node, ...props }) => {
      const src = props.src.startsWith("http")
        ? props.src
        : `${window.location.origin}${props.src}`;

      return (
        <img
          {...props}
          src={src}
          alt={props.alt || "이미지"}
          loading="lazy"
          className="post-detail__image"
        />
      );
    },
  }}
>
  {cleanContent}
</ReactMarkdown>
```

---

### 테스트 방법

1. **테스트 환경**
    - React 18, Vite 환경에서 테스트 진행
    - 마크다운으로 작성된 포스트를 렌더링하여 형광펜 및 강조 마크업이 정상적으로 동작하는지 확인
2. **테스트 시나리오**
    - `==(파랑)강조 텍스트==`를 사용하여 형광펜이 정상적으로 렌더링되는지 확인
    - 리스트 항목 및 일반 문단에서 HTML 마크업이 포함된 경우 `dangerouslySetInnerHTML`로 안전하게 렌더링되는지 테스트
3. **결과**
    - 하이라이트 및 강조가 정상적으로 렌더링됨
    - 보안 문제 없이 XSS 방지됨

---

### UI 변경 사항

**변경 전:**

`==(파랑)강조 텍스트==`가 그대로 텍스트로 출력됨

**변경 후:**

`==(파랑)강조 텍스트==`가 `<mark class="highlight highlight--blue">강조 텍스트</mark>`로 변환됨

---

### 추가 정보

- `dangerouslySetInnerHTML`은 DOMPurify를 사용해 필터링된 상태로 삽입되므로 보안상 문제가 없습니다.
- UI/UX에서 강조가 필요한 부분에 더 직관적인 표시가 가능합니다.